### PR TITLE
Support jruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 bundler_args: --without development
-rvm:
-  - jruby
-env:
-  - JRUBY_OPTS=--1.9
-  - JRUBY_OPTS=--2.0
-jdk:
-  - openjdk7
+matrix:
+  include:
+    - rvm: jruby
+      env: JRUBY_OPTS=--1.9
+    - rvm: jruby
+      env: JRUBY_OPTS=--2.0
+    - rvm: jruby-head

--- a/ext/java/org/msgpack/jruby/MessagePackLibrary.java
+++ b/ext/java/org/msgpack/jruby/MessagePackLibrary.java
@@ -12,7 +12,6 @@ import org.jruby.RubyString;
 import org.jruby.RubyObject;
 import org.jruby.RubyHash;
 import org.jruby.RubyIO;
-import org.jruby.RubyStringIO;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyEnumerator;
 import org.jruby.runtime.load.Library;
@@ -230,9 +229,9 @@ public class MessagePackLibrary implements Library {
     public IRubyObject setStream(ThreadContext ctx, IRubyObject stream) {
       bufferUnpacker = null;
       this.stream = stream;
-      if (stream instanceof RubyStringIO) {
-        // TODO: RubyStringIO returns negative numbers when read through IOInputStream#read
-        IRubyObject str = ((RubyStringIO) stream).string();
+      RubyClass stringio = ctx.getRuntime().getClass("StringIO");
+      if (stringio != null && stringio.isInstance(stream)) {
+        IRubyObject str = stream.callMethod(ctx, "string");
         byte[] bytes = ((RubyString) str).getBytes();
         streamUnpacker = new MessagePackUnpacker(msgPack, new ByteArrayInputStream(bytes));
       } else {

--- a/ext/java/org/msgpack/jruby/RubyObjectPacker.java
+++ b/ext/java/org/msgpack/jruby/RubyObjectPacker.java
@@ -121,7 +121,7 @@ public class RubyObjectPacker {
   private void write(BufferPacker packer, RubyString str, CompiledOptions options) throws IOException {
     if ((options.encoding != null) && (str.getEncoding() != options.encoding)) {
       Ruby runtime = str.getRuntime();
-      str = (RubyString) str.encode(runtime.getCurrentContext(), RubyEncoding.newEncoding(runtime, options.encoding));
+      str = (RubyString) str.encode(runtime.getCurrentContext(), runtime.getEncodingService().getEncoding(options.encoding));
     }
     packer.write(str.getBytes());
   }


### PR DESCRIPTION
As JRuby 9k is approaching release, it makes sense to add support for it. Only two small code-changes were required in order to get it up and running. I have confirmed that the new code paths work locally using jruby-1.7.2 and jruby-1.7.6 in addition to the environments tested on travis.
